### PR TITLE
modify wrong tag of logback config  & change Thread.sleep() to TimeUn…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ repositories {
 dependencies {
     compile 'org.apache.commons:commons-lang3:3.4'
     compile 'ch.qos.logback:logback-classic:1.1.7'
+    compile 'ch.qos.logback:logback-core:1.1.7'
     compile 'org.projectlombok:lombok:1.16.10'
 
     testCompile 'junit:junit:4.11'

--- a/src/main/java/net/joey/concurrency/ReentrantLockMain.java
+++ b/src/main/java/net/joey/concurrency/ReentrantLockMain.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.IntStream;
 
@@ -39,7 +40,7 @@ public class ReentrantLockMain {
                     }
 
                     try {
-                        Thread.sleep(1000);
+                        TimeUnit.SECONDS.sleep(1);
                     } catch (InterruptedException e) {
                         e.printStackTrace();
                     }
@@ -64,7 +65,7 @@ public class ReentrantLockMain {
                 }
 
                 try {
-                    Thread.sleep(2000);
+                    TimeUnit.SECONDS.sleep(2);
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }

--- a/src/main/java/net/joey/concurrency/ReentrantReadWriteLockMain.java
+++ b/src/main/java/net/joey/concurrency/ReentrantReadWriteLockMain.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.IntStream;
 
@@ -31,40 +32,44 @@ public class ReentrantReadWriteLockMain {
 
         IntStream.range(0, 2).forEach(i -> {
             Thread producer = new Thread(() -> {
-                try {
-                    writeLock.lock();
-                    IntStream.range(0, 10).forEach(item -> {
-                        list.add(String.valueOf(item));
-                    });
-                } finally {
-                    writeLock.unlock();
-                }
+                while (true) {
+                    try {
+                        writeLock.lock();
+                        IntStream.range(0, 10).forEach(item -> {
+                            list.add(String.valueOf(item));
+                        });
+                    } finally {
+                        writeLock.unlock();
+                    }
 
-                try {
-                    Thread.sleep(200);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    try {
+                        TimeUnit.SECONDS.sleep(2);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
                 }
             });
             producer.start();
         });
 
         Thread consumer = new Thread(() -> {
-            try {
-                readLock.lock();
-                StringBuffer sb = new StringBuffer();
-                list.stream().forEach(item -> {
-                    sb.append(item).append(' ');
-                });
-                log.info(sb.toString());
-            } finally {
-                list.clear();
-                readLock.unlock();
-            }
-            try {
-                Thread.sleep(300);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
+            while (true) {
+                try {
+                    readLock.lock();
+                    StringBuffer sb = new StringBuffer();
+                    list.stream().forEach(item -> {
+                        sb.append(item).append(' ');
+                    });
+                    log.info(sb.toString());
+                } finally {
+                    list.clear();
+                    readLock.unlock();
+                }
+                try {
+                    TimeUnit.SECONDS.sleep(3);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
             }
         });
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<included>
+<configuration>
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <pattern>▶ %-5level %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %logger{36}[%method:%line] - %msg%n</pattern>
@@ -9,4 +9,4 @@
     <root level="info">
         <appender-ref ref="console" />
     </root>
-</included>
+</configuration>


### PR DESCRIPTION
…it.SECONDS.sleep() for human readability
1. logback.xml 은  <configuration></configuration> 으로 구성되어야 하는데 잘못된 태그를 사용하여  Console Log가 제대로 찍히지 않았다. 
2. java.util.concurrent.TimeUnit를 사용하여, 가독성을 높였다. 
